### PR TITLE
ModExp function: remove padding & code clean

### DIFF
--- a/ipcl/include/ipcl/mod_exp.hpp
+++ b/ipcl/include/ipcl/mod_exp.hpp
@@ -12,23 +12,23 @@ namespace ipcl {
 /**
  * Modular exponentiation for multi buffer
  * @param[in] base base of the exponentiation
- * @param[in] pow pow of the exponentiation
- * @param[in] m modular
+ * @param[in] exp pow of the exponentiation
+ * @param[in] mod modular
  * @return the modular exponentiation result of type BigNumber
  */
 std::vector<BigNumber> ippModExp(const std::vector<BigNumber>& base,
-                                 const std::vector<BigNumber>& pow,
-                                 const std::vector<BigNumber>& m);
+                                 const std::vector<BigNumber>& exp,
+                                 const std::vector<BigNumber>& mod);
 
 /**
  * Modular exponentiation for single buffer
  * @param[in] base base of the exponentiation
- * @param[in] pow pow of the exponentiation
- * @param[in] m modular
+ * @param[in] exp pow of the exponentiation
+ * @param[in] mod modular
  * @return the modular exponentiation result of type BigNumber
  */
-BigNumber ippModExp(const BigNumber& base, const BigNumber& pow,
-                    const BigNumber& m);
+BigNumber ippModExp(const BigNumber& base, const BigNumber& exp,
+                    const BigNumber& mod);
 
 }  // namespace ipcl
 #endif  // IPCL_INCLUDE_IPCL_MOD_EXP_HPP_

--- a/ipcl/mod_exp.cpp
+++ b/ipcl/mod_exp.cpp
@@ -14,124 +14,131 @@
 namespace ipcl {
 
 static std::vector<BigNumber> ippMBModExp(const std::vector<BigNumber>& base,
-                                          const std::vector<BigNumber>& pow,
-                                          const std::vector<BigNumber>& m) {
-  VEC_SIZE_CHECK(base);
-  VEC_SIZE_CHECK(pow);
-  VEC_SIZE_CHECK(m);
+                                          const std::vector<BigNumber>& exp,
+                                          const std::vector<BigNumber>& mod) {
+  std::size_t real_v_size = base.size();
+  std::size_t pow_v_size = exp.size();
+  std::size_t mod_v_size = mod.size();
+  ERROR_CHECK((real_v_size == pow_v_size) && (pow_v_size == mod_v_size) &&
+                  (real_v_size <= IPCL_CRYPTO_MB_SIZE),
+              "ippMBModExp: input vector size error");
 
   mbx_status st = MBX_STATUS_OK;
 
-  int bits = m.front().BitSize();
-  int dwords = BITSIZE_DWORD(bits);
-  int bufferLen = mbx_exp_BufferSize(bits);
-  auto buffer = std::vector<Ipp8u>(bufferLen);
-
-  std::vector<int64u*> out_x(IPCL_CRYPTO_MB_SIZE);
-  std::vector<int64u*> b_array(IPCL_CRYPTO_MB_SIZE);
-  std::vector<int64u*> p_array(IPCL_CRYPTO_MB_SIZE);
-
-  int mem_pool_size = IPCL_CRYPTO_MB_SIZE * dwords;
-  std::vector<int64u> out_mem_pool(mem_pool_size);
-  std::vector<int64u> base_mem_pool(mem_pool_size);
-  std::vector<int64u> pow_mem_pool(mem_pool_size);
-
-  for (int i = 0; i < IPCL_CRYPTO_MB_SIZE; i++) {
-    out_x[i] = &out_mem_pool[i * dwords];
-    b_array[i] = &base_mem_pool[i * dwords];
-    p_array[i] = &pow_mem_pool[i * dwords];
-  }
-
   /*
-   * These two intermediate variables pow_b & pow_p are necessary
+   * These two intermediate variables base_data & exp_data are necessary
    * because if they are not used, the length returned from ippsRef_BN
-   * will be inconsistent with the length allocated by b_array/p_array,
+   * will be inconsistent with the length allocated by base_pa/exp_pa,
    * resulting in data errors.
    */
-  std::vector<Ipp32u*> pow_b(IPCL_CRYPTO_MB_SIZE);
-  std::vector<Ipp32u*> pow_p(IPCL_CRYPTO_MB_SIZE);
-  std::vector<Ipp32u*> pow_nsquare(IPCL_CRYPTO_MB_SIZE);
-  std::vector<int> b_size_v(IPCL_CRYPTO_MB_SIZE);
-  std::vector<int> p_size_v(IPCL_CRYPTO_MB_SIZE);
-  std::vector<int> n_size_v(IPCL_CRYPTO_MB_SIZE);
+  std::vector<Ipp32u*> base_data(IPCL_CRYPTO_MB_SIZE);
+  std::vector<Ipp32u*> exp_data(IPCL_CRYPTO_MB_SIZE);
+  std::vector<Ipp32u*> mod_data(IPCL_CRYPTO_MB_SIZE);
+  std::vector<int> base_bits_v(IPCL_CRYPTO_MB_SIZE);
+  std::vector<int> exp_bits_v(IPCL_CRYPTO_MB_SIZE);
+  std::vector<int> mod_bits_v(IPCL_CRYPTO_MB_SIZE);
 
-  for (int i = 0; i < IPCL_CRYPTO_MB_SIZE; i++) {
-    ippsRef_BN(nullptr, &b_size_v[i], reinterpret_cast<Ipp32u**>(&pow_b[i]),
-               base[i]);
-    ippsRef_BN(nullptr, &p_size_v[i], reinterpret_cast<Ipp32u**>(&pow_p[i]),
-               pow[i]);
-    ippsRef_BN(nullptr, &n_size_v[i], &pow_nsquare[i], m[i]);
-
-    memcpy(b_array[i], pow_b[i], BITSIZE_WORD(b_size_v[i]) * 4);
-    memcpy(p_array[i], pow_p[i], BITSIZE_WORD(p_size_v[i]) * 4);
+  for (int i = 0; i < real_v_size; i++) {
+    ippsRef_BN(nullptr, &base_bits_v[i],
+               reinterpret_cast<Ipp32u**>(&base_data[i]), base[i]);
+    ippsRef_BN(nullptr, &exp_bits_v[i],
+               reinterpret_cast<Ipp32u**>(&exp_data[i]), exp[i]);
+    ippsRef_BN(nullptr, &mod_bits_v[i], &mod_data[i], mod[i]);
   }
 
-  // Find the biggest size of module and exp
-  int nsqBitLen = *std::max_element(n_size_v.begin(), n_size_v.end());
-  int expBitLen = *std::max_element(p_size_v.begin(), p_size_v.end());
+  // Find the longest size of module and power
+  auto longest_mod_it = std::max_element(mod_bits_v.begin(), mod_bits_v.end());
+  auto longest_mod_idx = std::distance(mod_bits_v.begin(), longest_mod_it);
+  BigNumber longest_mod = mod[longest_mod_idx];
+  int mod_bits = *longest_mod_it;
+  int exp_bits = *std::max_element(exp_bits_v.begin(), exp_bits_v.end());
 
+  std::vector<int64u*> out_pa(IPCL_CRYPTO_MB_SIZE);
+  std::vector<int64u*> base_pa(IPCL_CRYPTO_MB_SIZE);
+  std::vector<int64u*> exp_pa(IPCL_CRYPTO_MB_SIZE);
+
+  int mod_dwords = BITSIZE_DWORD(mod_bits);
+  int num_buff = IPCL_CRYPTO_MB_SIZE * mod_dwords;
+  std::vector<int64u> out_buff(num_buff);
+  std::vector<int64u> base_buff(num_buff);
+  std::vector<int64u> exp_buff(num_buff);
+
+  for (int i = 0; i < IPCL_CRYPTO_MB_SIZE; i++) {
+    auto idx = i * mod_dwords;
+    out_pa[i] = &out_buff[idx];
+    base_pa[i] = &base_buff[idx];
+    exp_pa[i] = &exp_buff[idx];
+  }
+
+  for (int i = 0; i < real_v_size; i++) {
+    memcpy(base_pa[i], base_data[i], BITSIZE_WORD(base_bits_v[i]) * 4);
+    memcpy(exp_pa[i], exp_data[i], BITSIZE_WORD(exp_bits_v[i]) * 4);
+  }
+
+  int work_buff_size = mbx_exp_BufferSize(mod_bits);
+  auto work_buff = std::vector<Ipp8u>(work_buff_size);
   // If actual sizes of modules are different,
   // set the mod_bits parameter equal to maximum size of the actual module in
   // bit size and extend all the modules with zero bits to the mod_bits value.
   // The same is applicable for the exp_bits parameter and actual exponents.
-  st = mbx_exp_mb8(out_x.data(), b_array.data(), p_array.data(), expBitLen,
-                   reinterpret_cast<Ipp64u**>(pow_nsquare.data()), nsqBitLen,
-                   reinterpret_cast<Ipp8u*>(buffer.data()), bufferLen);
+  st = mbx_exp_mb8(out_pa.data(), base_pa.data(), exp_pa.data(), exp_bits,
+                   reinterpret_cast<Ipp64u**>(mod_data.data()), mod_bits,
+                   reinterpret_cast<Ipp8u*>(work_buff.data()), work_buff_size);
 
-  for (int i = 0; i < IPCL_CRYPTO_MB_SIZE; i++) {
+  for (int i = 0; i < real_v_size; i++) {
     ERROR_CHECK(MBX_STATUS_OK == MBX_GET_STS(st, i),
                 std::string("ippMultiBuffExp: error multi buffered exp "
                             "modules, error code = ") +
                     std::to_string(MBX_GET_STS(st, i)));
   }
 
-  // It is important to hold a copy of nsquare for thread-safe purpose
-  std::vector<BigNumber> res(IPCL_CRYPTO_MB_SIZE, m.front());
-
-  for (int i = 0; i < IPCL_CRYPTO_MB_SIZE; i++) {
-    res[i].Set(reinterpret_cast<Ipp32u*>(out_x[i]), BITSIZE_WORD(nsqBitLen),
+  // Init res with longest mod value to ensure each
+  // Big number has enough space.
+  std::vector<BigNumber> res(real_v_size, longest_mod);
+  for (int i = 0; i < real_v_size; i++) {
+    res[i].Set(reinterpret_cast<Ipp32u*>(out_pa[i]), BITSIZE_WORD(mod_bits),
                IppsBigNumPOS);
   }
   return res;
 }
 
-static BigNumber ippSBModExp(const BigNumber& base, const BigNumber& pow,
-                             const BigNumber& m) {
+static BigNumber ippSBModExp(const BigNumber& base, const BigNumber& exp,
+                             const BigNumber& mod) {
   IppStatus stat = ippStsNoErr;
   // It is important to declare res * bform bit length refer to ipp-crypto spec:
   // R should not be less than the data length of the modulus m
-  BigNumber res(m);
+  BigNumber res(mod);
 
-  int bnBitLen;
-  Ipp32u* pow_m;
-  ippsRef_BN(nullptr, &bnBitLen, &pow_m, BN(m));
-  int nlen = BITSIZE_WORD(bnBitLen);
+  int mod_bits;
+  Ipp32u* mod_data;
+  ippsRef_BN(nullptr, &mod_bits, &mod_data, BN(mod));
+  int mod_words = BITSIZE_WORD(mod_bits);
 
   int size;
   // define and initialize Montgomery Engine over Modulus N
-  stat = ippsMontGetSize(IppsBinaryMethod, nlen, &size);
+  stat = ippsMontGetSize(IppsBinaryMethod, mod_words, &size);
   ERROR_CHECK(stat == ippStsNoErr,
               "ippMontExp: get the size of IppsMontState context error.");
 
   auto pMont = std::vector<Ipp8u>(size);
 
-  stat = ippsMontInit(IppsBinaryMethod, nlen,
+  stat = ippsMontInit(IppsBinaryMethod, mod_words,
                       reinterpret_cast<IppsMontState*>(pMont.data()));
   ERROR_CHECK(stat == ippStsNoErr, "ippMontExp: init Mont context error.");
 
-  stat =
-      ippsMontSet(pow_m, nlen, reinterpret_cast<IppsMontState*>(pMont.data()));
+  stat = ippsMontSet(mod_data, mod_words,
+                     reinterpret_cast<IppsMontState*>(pMont.data()));
   ERROR_CHECK(stat == ippStsNoErr, "ippMontExp: set Mont input error.");
 
   // encode base into Montgomery form
-  BigNumber bform(m);
+  BigNumber bform(mod);
   stat = ippsMontForm(BN(base), reinterpret_cast<IppsMontState*>(pMont.data()),
                       BN(bform));
   ERROR_CHECK(stat == ippStsNoErr,
               "ippMontExp: convert big number into Mont form error.");
 
   // compute R = base^pow mod N
-  stat = ippsMontExp(BN(bform), BN(pow),
+  stat = ippsMontExp(BN(bform), BN(exp),
                      reinterpret_cast<IppsMontState*>(pMont.data()), BN(res));
   ERROR_CHECK(stat == ippStsNoErr,
               std::string("ippsMontExp: error code = ") + std::to_string(stat));
@@ -148,8 +155,8 @@ static BigNumber ippSBModExp(const BigNumber& base, const BigNumber& pow,
 }
 
 std::vector<BigNumber> ippModExp(const std::vector<BigNumber>& base,
-                                 const std::vector<BigNumber>& pow,
-                                 const std::vector<BigNumber>& m) {
+                                 const std::vector<BigNumber>& exp,
+                                 const std::vector<BigNumber>& mod) {
   std::size_t v_size = base.size();
   std::vector<BigNumber> res(v_size);
 
@@ -157,13 +164,13 @@ std::vector<BigNumber> ippModExp(const std::vector<BigNumber>& base,
 
   // If there is only 1 big number, we don't need to use MBModExp
   if (v_size == 1) {
-    res[0] = ippSBModExp(base[0], pow[0], m[0]);
+    res[0] = ippSBModExp(base[0], exp[0], mod[0]);
     return res;
   }
 
-  std::size_t offset = 0;
-  std::size_t num_chunk = v_size / IPCL_CRYPTO_MB_SIZE;
   std::size_t remainder = v_size % IPCL_CRYPTO_MB_SIZE;
+  std::size_t num_chunk =
+      (v_size + IPCL_CRYPTO_MB_SIZE - 1) / IPCL_CRYPTO_MB_SIZE;
 
 #ifdef IPCL_USE_OMP
   int omp_remaining_threads = OMPUtilities::MaxThreads;
@@ -171,49 +178,26 @@ std::vector<BigNumber> ippModExp(const std::vector<BigNumber>& base,
     OMPUtilities::assignOMPThreads(omp_remaining_threads, num_chunk))
 #endif  // IPCL_USE_OMP
   for (std::size_t i = 0; i < num_chunk; i++) {
-    auto base_start = base.begin() + i * IPCL_CRYPTO_MB_SIZE;
-    auto base_end = base_start + IPCL_CRYPTO_MB_SIZE;
+    std::size_t chunk_size = IPCL_CRYPTO_MB_SIZE;
+    if ((i == (num_chunk - 1)) && (remainder > 1)) chunk_size = remainder;
 
-    auto pow_start = pow.begin() + i * IPCL_CRYPTO_MB_SIZE;
-    auto pow_end = pow_start + IPCL_CRYPTO_MB_SIZE;
+    std::size_t chunk_offset = i * IPCL_CRYPTO_MB_SIZE;
 
-    auto m_start = m.begin() + i * IPCL_CRYPTO_MB_SIZE;
-    auto m_end = m_start + IPCL_CRYPTO_MB_SIZE;
+    auto base_start = base.begin() + chunk_offset;
+    auto base_end = base_start + chunk_size;
+
+    auto exp_start = exp.begin() + chunk_offset;
+    auto exp_end = exp_start + chunk_size;
+
+    auto mod_start = mod.begin() + chunk_offset;
+    auto mod_end = mod_start + chunk_size;
 
     auto base_chunk = std::vector<BigNumber>(base_start, base_end);
-    auto pow_chunk = std::vector<BigNumber>(pow_start, pow_end);
-    auto m_chunk = std::vector<BigNumber>(m_start, m_end);
+    auto exp_chunk = std::vector<BigNumber>(exp_start, exp_end);
+    auto mod_chunk = std::vector<BigNumber>(mod_start, mod_end);
 
-    auto tmp = ippMBModExp(base_chunk, pow_chunk, m_chunk);
-    std::copy(tmp.begin(), tmp.end(), res.begin() + i * IPCL_CRYPTO_MB_SIZE);
-  }
-
-  offset = num_chunk * IPCL_CRYPTO_MB_SIZE;
-  // If only 1 big number left, we don't need to make padding
-  if (remainder == 1)
-    res[offset] = ippSBModExp(base[offset], pow[offset], m[offset]);
-
-  // If the 1 < remainder < IPCL_CRYPTO_MB_SIZE, we need to make padding
-  if (remainder > 1) {
-    auto base_start = base.begin() + offset;
-    auto base_end = base_start + remainder;
-
-    auto pow_start = pow.begin() + offset;
-    auto pow_end = pow_start + remainder;
-
-    auto m_start = m.begin() + offset;
-    auto m_end = m_start + remainder;
-
-    std::vector<BigNumber> base_chunk(IPCL_CRYPTO_MB_SIZE, 0);
-    std::vector<BigNumber> pow_chunk(IPCL_CRYPTO_MB_SIZE, 0);
-    std::vector<BigNumber> m_chunk(IPCL_CRYPTO_MB_SIZE, 0);
-
-    std::copy(base_start, base_end, base_chunk.begin());
-    std::copy(pow_start, pow_end, pow_chunk.begin());
-    std::copy(m_start, m_end, m_chunk.begin());
-
-    auto tmp = ippMBModExp(base_chunk, pow_chunk, m_chunk);
-    std::copy(tmp.begin(), tmp.begin() + remainder, res.begin() + offset);
+    auto tmp = ippMBModExp(base_chunk, exp_chunk, mod_chunk);
+    std::copy(tmp.begin(), tmp.end(), res.begin() + chunk_offset);
   }
 
   return res;
@@ -225,15 +209,16 @@ std::vector<BigNumber> ippModExp(const std::vector<BigNumber>& base,
 #pragma omp parallel for num_threads( \
     OMPUtilities::assignOMPThreads(omp_remaining_threads, v_size))
 #endif  // IPCL_USE_OMP
-  for (int i = 0; i < v_size; i++) res[i] = ippSBModExp(base[i], pow[i], m[i]);
+  for (int i = 0; i < v_size; i++)
+    res[i] = ippSBModExp(base[i], exp[i], mod[i]);
   return res;
 
 #endif  // IPCL_CRYPTO_MB_MOD_EXP
 }
 
-BigNumber ippModExp(const BigNumber& base, const BigNumber& pow,
-                    const BigNumber& m) {
-  return ippSBModExp(base, pow, m);
+BigNumber ippModExp(const BigNumber& base, const BigNumber& exp,
+                    const BigNumber& mod) {
+  return ippSBModExp(base, exp, mod);
 }
 
 }  // namespace ipcl


### PR DESCRIPTION
1. Remove padding operation in `ippsModExp` function.  
2. Let `ippsMBModExp` function support modulus of different bit size(in one vector).
3. some code clean.