### PR TITLE
Removing seed setup and replacing rng function for PrimeGen_BN

### DIFF
--- a/ipcl/include/ipcl/common.hpp
+++ b/ipcl/include/ipcl/common.hpp
@@ -11,11 +11,31 @@ namespace ipcl {
 constexpr int IPCL_CRYPTO_MB_SIZE = 8;
 
 /**
- * Get random value
- * @param[in] length bit length
- * @return the random value of type BigNumber
+ * Random generator wrapper.Generates a random unsigned Big Number of the
+ * specified bit length
+ * @param[in] rand Pointer to the output unsigned integer big number
+ * @param[in] bits The number of generated bits
+ * @param[in] ctx Pointer to the IppsPRNGState context.
+ * @return Error code
  */
-BigNumber getRandomBN(int length);
+IppStatus ippGenRandom(Ipp32u* rand, int bits, void* ctx);
+
+/**
+ * Random generator wrapper.Generates a random positive Big Number of the
+ * specified bit length
+ * @param[in] rand Pointer to the output Big Number
+ * @param[in] bits The number of generated bits
+ * @param[in] ctx Pointer to the IppsPRNGState context.
+ * @return Error code
+ */
+IppStatus ippGenRandomBN(IppsBigNumState* rand, int bits, void* ctx);
+
+/**
+ * Get random value
+ * @param[in] bits The number of Big Number bits
+ * @return The random value of type Big Number
+ */
+BigNumber getRandomBN(int bits);
 
 }  // namespace ipcl
 #endif  // IPCL_INCLUDE_IPCL_COMMON_HPP_


### PR DESCRIPTION
1. getPrimeBN: remove seed setup
2. ippsPrimeGen_BN: add support to `TRNGen_RDSEED` and `PRNGen_RDRAND` 
3. ippsPrimeGen_BN: set the last parameter to `NULL` when using `ippsTRNGenRDSEED` or `ippsPRNGenRDRAND`. According to IPP source code and document, the parameter will used in `rndFunc`(line 105), which is `ippsTRNGenRDSEED`/`ippsPRNGenRDRAND`/`ippsPRNGen` in our case. The 3rd parameter of `ippsTRNGenRDSEED` and `ippsPRNGenRDRAND` is unused and can be NULL. (https://www.intel.com/content/www/us/en/develop/documentation/ipp-crypto-reference/top/public-key-cryptography-functions/pseudorandom-number-generation-functions/trngenrdseed.html)   
![image](https://user-images.githubusercontent.com/10611133/185081832-16f60cc2-1df4-4f63-90ae-c14e374f51ab.png)
![image](https://user-images.githubusercontent.com/10611133/185082666-2ab00c97-dbe4-47a6-8f3c-c7d0a6f27279.png)

