### PR TITLE
Detect preinstalled ippcrypto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ option(IPCL_DOCS "Enable document building" OFF)
 option(IPCL_SHARED "Build shared library" ON)
 option(IPCL_DETECT_CPU_RUNTIME "Detect CPU supported instructions during runtime" OFF)
 option(IPCL_INTERNAL_PYTHON_BUILD "Additional steps for IPCL_Python build" OFF)
+option(IPCL_IPPCRYPTO_PATH "Use pre-installed IPP-Crypto library" OFF)
 
 # Used only for ipcl_python IPCL_INTERNAL_PYTHON_BUILD - additional check if invalid parameters
 if(IPCL_INTERNAL_PYTHON_BUILD)
@@ -205,7 +206,7 @@ endif()
 
 if(IPCL_ENABLE_QAT)
   # preset values for including HE_QAT
-  set(HE_QAT_MISC OFF) # revisit later on
+  set(HE_QAT_MISC OFF)
   set(HE_QAT_DOCS ${IPCL_DOCS})
   set(HE_QAT_SHARED ${IPCL_SHARED})
   set(HE_QAT_TEST OFF)

--- a/cmake/ippcrypto.cmake
+++ b/cmake/ippcrypto.cmake
@@ -4,93 +4,156 @@
 include(ExternalProject)
 message(STATUS "Configuring ipp-crypto")
 
-set(IPPCRYPTO_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ext_ipp-crypto)
-set(IPPCRYPTO_DESTDIR ${IPPCRYPTO_PREFIX}/ippcrypto_install)
-set(IPPCRYPTO_DEST_INCLUDE_DIR include/ippcrypto)
-set(IPPCRYPTO_GIT_REPO_URL https://github.com/intel/ipp-crypto.git)
-set(IPPCRYPTO_GIT_LABEL ippcp_2021.6)
-set(IPPCRYPTO_SRC_DIR ${IPPCRYPTO_PREFIX}/src/ext_ipp-crypto/)
-
-set(IPPCRYPTO_CXX_FLAGS "${IPCL_FORWARD_CMAKE_ARGS} -DNONPIC_LIB:BOOL=off -DMERGED_BLD:BOOL=on")
-
-set(IPPCRYPTO_ARCH intel64)
-set(BUILD_x64 ON)
-if(BUILD_x64)
-  if(NOT ${BUILD_x64})
-    set(IPPCRYPTO_ARCH ia32)
+if(IPCL_IPPCRYPTO_PATH)
+  if(IPCL_SHARED)
+    set(IPPCP_SHARED ON)
+  else()
+    set(IPPCP_SHARED OFF)
   endif()
+
+  find_package(ippcp 11.4 HINTS ${IPCL_IPPCRYPTO_PATH}/lib/cmake/ippcp)
 endif()
 
-ExternalProject_Add(
-  ext_ipp-crypto
-  GIT_REPOSITORY ${IPPCRYPTO_GIT_REPO_URL}
-  GIT_TAG ${IPPCRYPTO_GIT_LABEL}
-  PREFIX ${IPPCRYPTO_PREFIX}
-  INSTALL_DIR ${IPPCRYPTO_PREFIX}
-  CMAKE_ARGS ${IPPCRYPTO_CXX_FLAGS}
-             -DCMAKE_INSTALL_PREFIX=${IPPCRYPTO_PREFIX}
-             -DARCH=${IPPCRYPTO_ARCH}
-             -DCMAKE_ASM_NASM_COMPILER=nasm
-             -DCMAKE_BUILD_TYPE=Release
-             -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
-             -DCMAKE_INSTALL_INCLUDEDIR=${IPPCRYPTO_DEST_INCLUDE_DIR}
-  UPDATE_COMMAND ""
-  PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/patch/ippcrypto_patch.patch
-  INSTALL_COMMAND make DESTDIR=${IPPCRYPTO_DESTDIR} install
-)
 
-set(IPPCRYPTO_INC_DIR ${IPPCRYPTO_DESTDIR}/${CMAKE_INSTALL_PREFIX}/include)
-set(IPPCRYPTO_LIB_DIR ${IPPCRYPTO_DESTDIR}/${CMAKE_INSTALL_PREFIX}/lib/${IPPCRYPTO_ARCH})
-if(IPCL_SHARED)
-  add_library(IPPCP INTERFACE)
-  add_library(IPPCP::ippcp ALIAS IPPCP)
+if(ippcp_FOUND)
+  message(STATUS "------------------ IPPCRYPTO FOUND!")
+  get_target_property(IPPCRYPTO_INC_DIR IPPCP::ippcp INTERFACE_INCLUDE_DIRECTORIES)
+  get_target_property(IPPCRYPTO_IMPORTED_LOCATION IPPCP::ippcp IMPORTED_LOCATION)
+  get_filename_component(IPPCRYPTO_LIB_DIR ${IPPCRYPTO_IMPORTED_LOCATION} DIRECTORY)
 
-  add_dependencies(IPPCP ext_ipp-crypto)
-
-  ExternalProject_Get_Property(ext_ipp-crypto SOURCE_DIR BINARY_DIR)
-
-  target_include_directories(IPPCP SYSTEM INTERFACE ${IPPCRYPTO_INC_DIR})
-
-  # if ipcl python build
-  if(IPCL_INTERNAL_PYTHON_BUILD)
-    target_link_libraries(IPPCP INTERFACE
-      ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/ippcrypto/libippcp.so
-      ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/ippcrypto/libcrypto_mb.so
-    )
-
-    add_custom_command(TARGET ext_ipp-crypto
-      POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy_directory ${IPPCRYPTO_LIB_DIR} ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/ippcrypto
-    )
-  else()
-    target_link_libraries(IPPCP INTERFACE
-      ${IPPCRYPTO_LIB_DIR}/libippcp.so
-      ${IPPCRYPTO_LIB_DIR}/libcrypto_mb.so
-    )
-  endif()
-
-  install(
-    DIRECTORY ${IPPCRYPTO_LIB_DIR}/
-    DESTINATION "${IPCL_INSTALL_LIBDIR}/ippcrypto"
-    USE_SOURCE_PERMISSIONS
-  )
+  message(STATUS "------------------ IPPCRYPTO_INC_DIR: ${IPPCRYPTO_INC_DIR}")
+  message(STATUS "------------------ IPPCRYPTO_LIB_DIR: ${IPPCRYPTO_LIB_DIR}")
 else()
 
-  add_library(IPPCP::ippcp STATIC IMPORTED GLOBAL)
-  add_library(IPPCP::crypto_mb STATIC IMPORTED GLOBAL)
+  set(IPPCRYPTO_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ext_ipp-crypto)
+  set(IPPCRYPTO_DESTDIR ${IPPCRYPTO_PREFIX}/ippcrypto_install)
+  set(IPPCRYPTO_DEST_INCLUDE_DIR include/ippcrypto)
+  set(IPPCRYPTO_GIT_REPO_URL https://github.com/intel/ipp-crypto.git)
+  set(IPPCRYPTO_GIT_LABEL ippcp_2021.6)
+  set(IPPCRYPTO_SRC_DIR ${IPPCRYPTO_PREFIX}/src/ext_ipp-crypto/)
 
-  add_dependencies(IPPCP::ippcp ext_ipp-crypto)
-  add_dependencies(IPPCP::crypto_mb ext_ipp-crypto)
+  set(IPPCRYPTO_CXX_FLAGS "${IPCL_FORWARD_CMAKE_ARGS} -DNONPIC_LIB:BOOL=off -DMERGED_BLD:BOOL=on")
 
-  find_package(OpenSSL REQUIRED)
+  set(IPPCRYPTO_ARCH intel64)
+  set(BUILD_x64 ON)
+  if(BUILD_x64)
+    if(NOT ${BUILD_x64})
+      set(IPPCRYPTO_ARCH ia32)
+    endif()
+  endif()
 
-  set_target_properties(IPPCP::ippcp PROPERTIES
-            IMPORTED_LOCATION ${IPPCRYPTO_LIB_DIR}/libippcp.a
-            INCLUDE_DIRECTORIES ${IPPCRYPTO_INC_DIR}
+  ExternalProject_Add(
+    ext_ipp-crypto
+    GIT_REPOSITORY ${IPPCRYPTO_GIT_REPO_URL}
+    GIT_TAG ${IPPCRYPTO_GIT_LABEL}
+    PREFIX ${IPPCRYPTO_PREFIX}
+    INSTALL_DIR ${IPPCRYPTO_PREFIX}
+    CMAKE_ARGS ${IPPCRYPTO_CXX_FLAGS}
+              -DCMAKE_INSTALL_PREFIX=${IPPCRYPTO_PREFIX}
+              -DARCH=${IPPCRYPTO_ARCH}
+              -DCMAKE_ASM_NASM_COMPILER=nasm
+              -DCMAKE_BUILD_TYPE=Release
+              -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+              -DCMAKE_INSTALL_INCLUDEDIR=${IPPCRYPTO_DEST_INCLUDE_DIR}
+    UPDATE_COMMAND ""
+    PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/patch/ippcrypto_patch.patch
+    INSTALL_COMMAND make DESTDIR=${IPPCRYPTO_DESTDIR} install
   )
 
-  set_target_properties(IPPCP::crypto_mb PROPERTIES
-            IMPORTED_LOCATION ${IPPCRYPTO_LIB_DIR}/libcrypto_mb.a
-            INCLUDE_DIRECTORIES ${IPPCRYPTO_INC_DIR}
-  )
+  set(IPPCRYPTO_INC_DIR ${IPPCRYPTO_DESTDIR}/${CMAKE_INSTALL_PREFIX}/include)
+  set(IPPCRYPTO_LIB_DIR ${IPPCRYPTO_DESTDIR}/${CMAKE_INSTALL_PREFIX}/lib/${IPPCRYPTO_ARCH})
+  if(IPCL_SHARED)
+    # add_library(IPPCP INTERFACE)
+    # add_library(IPPCP::ippcp ALIAS IPPCP)
+
+    # add_dependencies(IPPCP ext_ipp-crypto)
+
+    # target_include_directories(IPPCP SYSTEM INTERFACE ${IPPCRYPTO_INC_DIR})
+
+    # # if ipcl python build
+    # if(IPCL_INTERNAL_PYTHON_BUILD)
+    #   target_link_libraries(IPPCP INTERFACE
+    #     ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/ippcrypto/libippcp.so
+    #     ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/ippcrypto/libcrypto_mb.so
+    #   )
+
+    #   add_custom_command(TARGET ext_ipp-crypto
+    #     POST_BUILD
+    #     COMMAND ${CMAKE_COMMAND} -E copy_directory ${IPPCRYPTO_LIB_DIR} ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/ippcrypto
+    #   )
+    # else()
+    #   target_link_libraries(IPPCP INTERFACE
+    #     ${IPPCRYPTO_LIB_DIR}/libippcp.so
+    #     ${IPPCRYPTO_LIB_DIR}/libcrypto_mb.so
+    #   )
+    # endif()
+
+    # install(
+    #   DIRECTORY ${IPPCRYPTO_LIB_DIR}/
+    #   DESTINATION "${IPCL_INSTALL_LIBDIR}/ippcrypto"
+    #   USE_SOURCE_PERMISSIONS
+    # )
+
+    add_library(IPPCP_ippcp INTERFACE)
+    add_library(IPPCP::ippcp ALIAS IPPCP_ippcp)
+
+    add_library(IPPCP_crypto_mb INTERFACE)
+    add_library(IPPCP::crypto_mb ALIAS IPPCP_crypto_mb)
+
+    add_dependencies(IPPCP_ippcp ext_ipp-crypto)
+    add_dependencies(IPPCP_crypto_mb ext_ipp-crypto)
+
+    target_include_directories(IPPCP_ippcp SYSTEM INTERFACE ${IPPCRYPTO_INC_DIR})
+    target_include_directories(IPPCP_crypto_mb SYSTEM INTERFACE ${IPPCRYPTO_INC_DIR})
+
+    # if ipcl python build
+    if(IPCL_INTERNAL_PYTHON_BUILD)
+      target_link_libraries(IPPCP_ippcp INTERFACE
+        ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/ippcrypto/libippcp.so
+      )
+      target_link_libraries(IPPCP_crypto_mb INTERFACE
+        ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/ippcrypto/libcrypto_mb.so
+      )
+
+      add_custom_command(TARGET ext_ipp-crypto
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${IPPCRYPTO_LIB_DIR} ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/ippcrypto
+      )
+    else()
+      target_link_libraries(IPPCP_ippcp INTERFACE
+        ${IPPCRYPTO_LIB_DIR}/libippcp.so
+      )
+      target_link_libraries(IPPCP_crypto_mb INTERFACE
+        ${IPPCRYPTO_LIB_DIR}/libcrypto_mb.so
+      )
+
+    endif()
+
+    install(
+      DIRECTORY ${IPPCRYPTO_LIB_DIR}/
+      DESTINATION "${IPCL_INSTALL_LIBDIR}/ippcrypto"
+      USE_SOURCE_PERMISSIONS
+    )
+
+
+  else()
+
+    add_library(IPPCP::ippcp STATIC IMPORTED GLOBAL)
+    add_library(IPPCP::crypto_mb STATIC IMPORTED GLOBAL)
+
+    add_dependencies(IPPCP::ippcp ext_ipp-crypto)
+    add_dependencies(IPPCP::crypto_mb ext_ipp-crypto)
+
+    find_package(OpenSSL REQUIRED)
+
+    set_target_properties(IPPCP::ippcp PROPERTIES
+              IMPORTED_LOCATION ${IPPCRYPTO_LIB_DIR}/libippcp.a
+              INCLUDE_DIRECTORIES ${IPPCRYPTO_INC_DIR}
+    )
+
+    set_target_properties(IPPCP::crypto_mb PROPERTIES
+              IMPORTED_LOCATION ${IPPCRYPTO_LIB_DIR}/libcrypto_mb.a
+              INCLUDE_DIRECTORIES ${IPPCRYPTO_INC_DIR}
+    )
+  endif()
 endif()

--- a/cmake/ippcrypto.cmake
+++ b/cmake/ippcrypto.cmake
@@ -23,6 +23,8 @@ if(ippcp_FOUND)
 
   message(STATUS "------------------ IPPCRYPTO_INC_DIR: ${IPPCRYPTO_INC_DIR}")
   message(STATUS "------------------ IPPCRYPTO_LIB_DIR: ${IPPCRYPTO_LIB_DIR}")
+
+
 else()
 
   set(IPPCRYPTO_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ext_ipp-crypto)
@@ -63,37 +65,6 @@ else()
   set(IPPCRYPTO_INC_DIR ${IPPCRYPTO_DESTDIR}/${CMAKE_INSTALL_PREFIX}/include)
   set(IPPCRYPTO_LIB_DIR ${IPPCRYPTO_DESTDIR}/${CMAKE_INSTALL_PREFIX}/lib/${IPPCRYPTO_ARCH})
   if(IPCL_SHARED)
-    # add_library(IPPCP INTERFACE)
-    # add_library(IPPCP::ippcp ALIAS IPPCP)
-
-    # add_dependencies(IPPCP ext_ipp-crypto)
-
-    # target_include_directories(IPPCP SYSTEM INTERFACE ${IPPCRYPTO_INC_DIR})
-
-    # # if ipcl python build
-    # if(IPCL_INTERNAL_PYTHON_BUILD)
-    #   target_link_libraries(IPPCP INTERFACE
-    #     ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/ippcrypto/libippcp.so
-    #     ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/ippcrypto/libcrypto_mb.so
-    #   )
-
-    #   add_custom_command(TARGET ext_ipp-crypto
-    #     POST_BUILD
-    #     COMMAND ${CMAKE_COMMAND} -E copy_directory ${IPPCRYPTO_LIB_DIR} ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/ippcrypto
-    #   )
-    # else()
-    #   target_link_libraries(IPPCP INTERFACE
-    #     ${IPPCRYPTO_LIB_DIR}/libippcp.so
-    #     ${IPPCRYPTO_LIB_DIR}/libcrypto_mb.so
-    #   )
-    # endif()
-
-    # install(
-    #   DIRECTORY ${IPPCRYPTO_LIB_DIR}/
-    #   DESTINATION "${IPCL_INSTALL_LIBDIR}/ippcrypto"
-    #   USE_SOURCE_PERMISSIONS
-    # )
-
     add_library(IPPCP_ippcp INTERFACE)
     add_library(IPPCP::ippcp ALIAS IPPCP_ippcp)
 

--- a/cmake/ippcrypto.cmake
+++ b/cmake/ippcrypto.cmake
@@ -11,27 +11,30 @@ if(IPCL_IPPCRYPTO_PATH)
     set(IPPCP_SHARED OFF)
   endif()
 
+  # ippcp version 11.4 - inline with ippcp_2021.6
   find_package(ippcp 11.4 HINTS ${IPCL_IPPCRYPTO_PATH}/lib/cmake/ippcp)
 endif()
 
-
 if(ippcp_FOUND)
-  message(STATUS "------------------ IPPCRYPTO FOUND!")
+  message(STATUS "IPP-Crypto Found - using pre-installed IPP-Crypto library")
   get_target_property(IPPCRYPTO_INC_DIR IPPCP::ippcp INTERFACE_INCLUDE_DIRECTORIES)
   get_target_property(IPPCRYPTO_IMPORTED_LOCATION IPPCP::ippcp IMPORTED_LOCATION)
   get_filename_component(IPPCRYPTO_LIB_DIR ${IPPCRYPTO_IMPORTED_LOCATION} DIRECTORY)
 
-  message(STATUS "------------------ IPPCRYPTO_INC_DIR: ${IPPCRYPTO_INC_DIR}")
-  message(STATUS "------------------ IPPCRYPTO_LIB_DIR: ${IPPCRYPTO_LIB_DIR}")
-
+  install(
+    DIRECTORY ${IPPCRYPTO_LIB_DIR}/
+    DESTINATION "${IPCL_INSTALL_LIBDIR}/ippcrypto"
+    USE_SOURCE_PERMISSIONS
+  )
 
 else()
+  message(STATUS "IPP-Crypto NOT Found - building from source")
 
   set(IPPCRYPTO_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ext_ipp-crypto)
   set(IPPCRYPTO_DESTDIR ${IPPCRYPTO_PREFIX}/ippcrypto_install)
   set(IPPCRYPTO_DEST_INCLUDE_DIR include/ippcrypto)
   set(IPPCRYPTO_GIT_REPO_URL https://github.com/intel/ipp-crypto.git)
-  set(IPPCRYPTO_GIT_LABEL ippcp_2021.6)
+  set(IPPCRYPTO_GIT_LABEL ippcp_2021.6) #ippcp version 11.4
   set(IPPCRYPTO_SRC_DIR ${IPPCRYPTO_PREFIX}/src/ext_ipp-crypto/)
 
   set(IPPCRYPTO_CXX_FLAGS "${IPCL_FORWARD_CMAKE_ARGS} -DNONPIC_LIB:BOOL=off -DMERGED_BLD:BOOL=on")
@@ -56,7 +59,6 @@ else()
               -DCMAKE_ASM_NASM_COMPILER=nasm
               -DCMAKE_BUILD_TYPE=Release
               -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
-              -DCMAKE_INSTALL_INCLUDEDIR=${IPPCRYPTO_DEST_INCLUDE_DIR}
     UPDATE_COMMAND ""
     PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/patch/ippcrypto_patch.patch
     INSTALL_COMMAND make DESTDIR=${IPPCRYPTO_DESTDIR} install
@@ -105,7 +107,6 @@ else()
       DESTINATION "${IPCL_INSTALL_LIBDIR}/ippcrypto"
       USE_SOURCE_PERMISSIONS
     )
-
 
   else()
 

--- a/ipcl/CMakeLists.txt
+++ b/ipcl/CMakeLists.txt
@@ -57,12 +57,12 @@ install(DIRECTORY ${CEREAL_INC_DIR}/
 
 # IPP-Crypto (third party dep): include and install definition
 target_include_directories(ipcl
-    PUBLIC $<BUILD_INTERFACE:${IPPCRYPTO_INC_DIR}/ippcrypto>
+    PUBLIC $<BUILD_INTERFACE:${IPPCRYPTO_INC_DIR}>
     PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ipcl/ippcrypto>
 )
 
 install(DIRECTORY ${IPPCRYPTO_INC_DIR}/
-    DESTINATION ${IPCL_INSTALL_INCLUDEDIR}
+    DESTINATION ${IPCL_INSTALL_INCLUDEDIR}/ippcrypto
     FILES_MATCHING
     PATTERN "*.hpp"
     PATTERN "*.h"

--- a/ipcl/CMakeLists.txt
+++ b/ipcl/CMakeLists.txt
@@ -68,24 +68,6 @@ install(DIRECTORY ${IPPCRYPTO_INC_DIR}/
     PATTERN "*.h"
 )
 
-# CPU_FEATURES (third party dep): include and install definition
-if(IPCL_DETECT_IFMA_RUNTIME)
-	target_include_directories(ipcl
-		PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-		PUBLIC $<BUILD_INTERFACE:${CPUFEATURES_INC_DIR}>
-		PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-	)
-	install(DIRECTORY ${CPUFEATURES_INC_DIR}/
-		DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}
-		FILES_MATCHING
-		PATTERN "*.hpp"
-		PATTERN "*.h"
-	)
-
-endif()
-
-
-
 # include and install definition of cpu_features
 if(IPCL_DETECT_CPU_RUNTIME)
 	target_include_directories(ipcl
@@ -96,8 +78,8 @@ if(IPCL_DETECT_CPU_RUNTIME)
 		DESTINATION ${IPCL_INSTALL_INCLUDEDIR}
 		FILES_MATCHING
 		PATTERN "*.hpp"
-		PATTERN "*.h")
-
+		PATTERN "*.h"
+    )
 endif()
 
 # include and install definition of he_qat

--- a/ipcl/CMakeLists.txt
+++ b/ipcl/CMakeLists.txt
@@ -123,7 +123,7 @@ if(IPCL_ENABLE_OMP)
 endif()
 
 if(IPCL_SHARED)
-	target_link_libraries(ipcl PRIVATE IPPCP::ippcp)
+	target_link_libraries(ipcl PRIVATE IPPCP::ippcp IPPCP::crypto_mb)
 	if(IPCL_DETECT_CPU_RUNTIME)
         target_link_libraries(ipcl PRIVATE libcpu_features)
 	endif()

--- a/ipcl/CMakeLists.txt
+++ b/ipcl/CMakeLists.txt
@@ -43,6 +43,7 @@ install(DIRECTORY ${IPCL_INC_DIR}/
 )
 
 # CEREAL (third party dep): include and install definition
+add_dependencies(ipcl ext_cereal)
 target_include_directories(ipcl
     PUBLIC $<BUILD_INTERFACE:${CEREAL_INC_DIR}>
 	PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ipcl>


### PR DESCRIPTION
Add feature to use pre-installed IPP-Crypto if path is specified via ```IPCL_IPPCRYPTO_PATH``` cmake flag