### PR TITLE
Replace IPCL_IPPCRYPTO_PATH with CMAKE_PREFIX_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,10 +46,7 @@ endif()
 if(CMAKE_PREFIX_PATH)
   message(STATUS "---- CMAKE_PREFIX_PATH is defined as ${CMAKE_PREFIX_PATH}")
 else()
-  set(CMAKE_PREFIX_PATH
-    $ENV{HOME}/intel
-    /opt/intel/ipp-crypto
-  )
+  set(CMAKE_PREFIX_PATH $ENV{HOME}/intel /opt/intel)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,16 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX "/opt/intel/ipcl")
 endif()
 
+if(CMAKE_PREFIX_PATH)
+  message(STATUS "---- CMAKE_PREFIX_PATH is defined as ${CMAKE_PREFIX_PATH}")
+else()
+  set(CMAKE_PREFIX_PATH
+    $ENV{HOME}/intel
+    /opt/intel/ipp-crypto
+  )
+endif()
+
+
 set(CMAKE_C_FLAGS "-O2 -Wno-error=deprecated-declarations -Wno-error=deprecated-copy")
 set(CMAKE_CXX_FLAGS "-O2 -fpermissive -Wno-error=deprecated-declarations -Wno-error=deprecated-copy")
 set(CMAKE_INSTALL_RPATH "$ORIGIN;$ORIGIN/${CMAKE_INSTALL_LIBDIR};$ORIGIN/ippcrypto")
@@ -70,7 +80,6 @@ option(IPCL_DOCS "Enable document building" OFF)
 option(IPCL_SHARED "Build shared library" ON)
 option(IPCL_DETECT_CPU_RUNTIME "Detect CPU supported instructions during runtime" OFF)
 option(IPCL_INTERNAL_PYTHON_BUILD "Additional steps for IPCL_Python build" OFF)
-option(IPCL_IPPCRYPTO_PATH "Use pre-installed IPP-Crypto library" OFF)
 
 # Used only for ipcl_python IPCL_INTERNAL_PYTHON_BUILD - additional check if invalid parameters
 if(IPCL_INTERNAL_PYTHON_BUILD)

--- a/cmake/ippcrypto.cmake
+++ b/cmake/ippcrypto.cmake
@@ -4,23 +4,23 @@
 include(ExternalProject)
 message(STATUS "Configuring ipp-crypto")
 
-if(IPCL_IPPCRYPTO_PATH)
+set(IPPCRYPTO_VERSION 11.4)
+set(IPPCRYPTO_GIT_LABEL ippcp_2021.6) #ippcp version 11.4
+
+if(CMAKE_PREFIX_PATH)
   if(IPCL_SHARED)
     set(IPPCP_SHARED ON)
   else()
     set(IPPCP_SHARED OFF)
   endif()
-
-  # ippcp version 11.4 - inline with ippcp_2021.6
-  find_package(ippcp 11.4 HINTS ${IPCL_IPPCRYPTO_PATH}/lib/cmake/ippcp)
+  find_package(ippcp ${IPPCRYPTO_VERSION})
 endif()
 
 if(ippcp_FOUND)
-  message(STATUS "IPP-Crypto Found - using pre-installed IPP-Crypto library")
+  message(STATUS "IPP-Crypto ${IPPCRYPTO_VERSION} found at ${ippcp_DIR}")
   get_target_property(IPPCRYPTO_INC_DIR IPPCP::ippcp INTERFACE_INCLUDE_DIRECTORIES)
   get_target_property(IPPCRYPTO_IMPORTED_LOCATION IPPCP::ippcp IMPORTED_LOCATION)
   get_filename_component(IPPCRYPTO_LIB_DIR ${IPPCRYPTO_IMPORTED_LOCATION} DIRECTORY)
-
   install(
     DIRECTORY ${IPPCRYPTO_LIB_DIR}/
     DESTINATION "${IPCL_INSTALL_LIBDIR}/ippcrypto"
@@ -28,13 +28,12 @@ if(ippcp_FOUND)
   )
 
 else()
-  message(STATUS "IPP-Crypto NOT Found - building from source")
+  message(STATUS "IPP-Crypto NOT found - building from source")
 
   set(IPPCRYPTO_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ext_ipp-crypto)
   set(IPPCRYPTO_DESTDIR ${IPPCRYPTO_PREFIX}/ippcrypto_install)
   set(IPPCRYPTO_DEST_INCLUDE_DIR include/ippcrypto)
   set(IPPCRYPTO_GIT_REPO_URL https://github.com/intel/ipp-crypto.git)
-  set(IPPCRYPTO_GIT_LABEL ippcp_2021.6) #ippcp version 11.4
   set(IPPCRYPTO_SRC_DIR ${IPPCRYPTO_PREFIX}/src/ext_ipp-crypto/)
 
   set(IPPCRYPTO_CXX_FLAGS "${IPCL_FORWARD_CMAKE_ARGS} -DNONPIC_LIB:BOOL=off -DMERGED_BLD:BOOL=on")


### PR DESCRIPTION
- Looks for installed IPP-Crypto on system with default locations at ${HOME}/intel and /opt/intel/ipp-crypto