### PR TITLE
Harden workflow for top level token permissions.

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -32,7 +32,6 @@ permissions:
   contents: read
   
 jobs:
-jobs:
   format:
     name: Format check
     runs-on: [self-hosted, linux, x64, icx, debian]

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -27,7 +27,11 @@ env:
   IPCL_DIR: ${GITHUB_WORKSPACE}/ipcl_install
   IPCL_HINT_DIR: >
       -DIPCL_HINT_DIR=${GITHUB_WORKSPACE}/ipcl_install/lib/cmake/ipcl-${IPCL_VER}
-
+      
+permissions:
+  contents: read
+  
+jobs:
 jobs:
   format:
     name: Format check


### PR DESCRIPTION
No top level token permission defined, This is required for compliance for OSSF Scorecard.